### PR TITLE
Fix formatting of authors field for more than two authors

### DIFF
--- a/bibtex/bibtex.go
+++ b/bibtex/bibtex.go
@@ -50,7 +50,7 @@ func abbrevAuthors(authors string) string {
 		return sl[0] + " & " + sl[1]
 	}
 	last := len(sl) - 1
-	return strings.Join(sl[0:last-1], ", ") + " & " + sl[last]
+	return strings.Join(sl[0:last], ", ") + " & " + sl[last]
 }
 
 func bibtool(bibFiles []string) *string {


### PR DESCRIPTION
Slices in go are half-open intervals, so using `sl[0:last-1]` and `sl[last]` in `abbrevAuthors` will return all authors except the second-to-last.

This PR changes the behavior to return all authors.