### PR TITLE
Add three biblatex fields to rsc and format them for printing.

### DIFF
--- a/bibtex/bibtex.go
+++ b/bibtex/bibtex.go
@@ -64,13 +64,16 @@ keep.field { author }
 keep.field { title }
 keep.field { year }
 keep.field { journal }
+keep.field { journaltitle }
 keep.field { booktitle }
 keep.field { editor }
 keep.field { publisher }
 keep.field { address }
+keep.field { location }
 keep.field { pages }
 keep.field { school }
 keep.field { volume }
+keep.field { url }
 rename.field { year = date if year = ".+" }
 add.field { year = "%-4.1d(date)" }
 new.entry.type{Article}

--- a/format/format.go
+++ b/format/format.go
@@ -18,7 +18,12 @@ func EntryToFZF(entry map[string]string) string {
 		s += "'" + entry["title"] + "'"
 		s += ", "
 		s += "\033[3m"
-		s += entry["journal"]
+	if entry["journal"] != "" {
+	    s += entry["journal"]
+	}
+	if entry["journaltitle"] != "" {
+	    s += entry["journaltitle"]
+	}
 		s += "\033[0m"
         if entry["volume"] != "" {
             s += " "
@@ -51,6 +56,12 @@ func EntryToFZF(entry map[string]string) string {
             s += ": "
             s += entry["publisher"]
         }
+	if entry["location"] != ""  {
+	    s += ", "
+	    s += entry["location"]
+	    s += ": "
+	    s += entry["publisher"]
+	}
 	case "incollection", "inproceedings", "inbook":
 		s += entry["author"]
 		s += " "
@@ -76,6 +87,12 @@ func EntryToFZF(entry map[string]string) string {
             s += ": "
             s += entry["publisher"]
         }
+	if entry["location"] != ""  {
+	    s += ", "
+	    s += entry["location"]
+	    s += ": "
+	    s += entry["publisher"]
+	}
         if entry["pages"] != "" {
             s += ", pp. "
             s += entry["pages"]
@@ -94,6 +111,13 @@ func EntryToFZF(entry map[string]string) string {
 		s += " "
 		s += "'" + entry["title"] + "'"
 		s += ", " + entry["school"]
+	case "online":
+		s += entry["author"]
+		s += " "
+		s += "(" + entry["year"] + ")"
+		s += " "
+		s += "'" + entry["title"] + "'"
+		s += ", " + entry["url"]
 	default:
 		if _, ok := entry["editor"]; ok {
 			s += entry["editor"]
@@ -137,7 +161,12 @@ func EntryToMarkdown(entry map[string]string) string {
 		s += "'" + entry["title"] + "'"
 		s += ", "
 		s += "*"
-		s += entry["journal"]
+	if entry["journal"] != "" {
+	    s += entry["journal"]
+	}
+	if entry["journaltitle"] != "" {
+	    s += entry["journaltitle"]
+	}
 		s += "*"
         if entry["volume"] != "" {
             s += " "
@@ -170,6 +199,12 @@ func EntryToMarkdown(entry map[string]string) string {
             s += ": "
             s += entry["publisher"]
         }
+	if entry["location"] != ""  {
+	    s += ", "
+	    s += entry["location"]
+	    s += ": "
+	    s += entry["publisher"]
+	}
 	case "incollection", "inproceedings", "inbook":
 		s += entry["author"]
 		s += " "
@@ -195,6 +230,12 @@ func EntryToMarkdown(entry map[string]string) string {
             s += ": "
             s += entry["publisher"]
         }
+	if entry["location"] != ""  {
+	    s += ", "
+	    s += entry["location"]
+	    s += ": "
+	    s += entry["publisher"]
+	}
         if entry["pages"] != "" {
             s += ", pp. "
             s += entry["pages"]
@@ -213,6 +254,13 @@ func EntryToMarkdown(entry map[string]string) string {
 		s += " "
 		s += "'" + entry["title"] + "'"
 		s += ", " + entry["school"]
+	case "online":
+		s += entry["author"]
+		s += " "
+		s += "(" + entry["year"] + ")"
+		s += " "
+		s += "'" + entry["title"] + "'"
+		s += ", " + entry["url"]
 	default:
 		if _, ok := entry["editor"]; ok {
 			s += entry["editor"]

--- a/format/format.go
+++ b/format/format.go
@@ -20,8 +20,7 @@ func EntryToFZF(entry map[string]string) string {
 		s += "\033[3m"
 	if entry["journal"] != "" {
 	    s += entry["journal"]
-	}
-	if entry["journaltitle"] != "" {
+	} else if entry["journaltitle"] != "" {
 	    s += entry["journaltitle"]
 	}
 		s += "\033[0m"
@@ -55,8 +54,7 @@ func EntryToFZF(entry map[string]string) string {
             s += entry["address"]
             s += ": "
             s += entry["publisher"]
-        }
-	if entry["location"] != ""  {
+        } else if entry["location"] != ""  {
 	    s += ", "
 	    s += entry["location"]
 	    s += ": "
@@ -86,8 +84,7 @@ func EntryToFZF(entry map[string]string) string {
             s += entry["address"]
             s += ": "
             s += entry["publisher"]
-        }
-	if entry["location"] != ""  {
+        } else if entry["location"] != ""  {
 	    s += ", "
 	    s += entry["location"]
 	    s += ": "
@@ -163,8 +160,7 @@ func EntryToMarkdown(entry map[string]string) string {
 		s += "*"
 	if entry["journal"] != "" {
 	    s += entry["journal"]
-	}
-	if entry["journaltitle"] != "" {
+	} else if entry["journaltitle"] != "" {
 	    s += entry["journaltitle"]
 	}
 		s += "*"
@@ -198,8 +194,7 @@ func EntryToMarkdown(entry map[string]string) string {
             s += entry["address"]
             s += ": "
             s += entry["publisher"]
-        }
-	if entry["location"] != ""  {
+        } else if entry["location"] != ""  {
 	    s += ", "
 	    s += entry["location"]
 	    s += ": "
@@ -229,8 +224,7 @@ func EntryToMarkdown(entry map[string]string) string {
             s += entry["address"]
             s += ": "
             s += entry["publisher"]
-        }
-	if entry["location"] != ""  {
+        } else if entry["location"] != ""  {
 	    s += ", "
 	    s += entry["location"]
 	    s += ": "

--- a/readme.md
+++ b/readme.md
@@ -222,13 +222,16 @@ keep.field { author }
 keep.field { title }
 keep.field { year }
 keep.field { journal }
+keep.field { journaltitle }
 keep.field { booktitle }
 keep.field { editor }
 keep.field { publisher }
 keep.field { address }
+keep.field { location }
 keep.field { pages }
 keep.field { school }
 keep.field { volume }
+keep.field { url }
 rename.field { year = date if year = ".+" }
 add.field { year = "%-4.1d(date)" }
 new.entry.type{Article}


### PR DESCRIPTION
### Reference Issue #17 

### What does this fix?

Biblatex has a slightly different naming convention to Bibtex for data fields. Currently, fzf-bibtex misses key fields, and has no format for 'online' type entries. This commit enables the parsing and printing of the following fields in biblatex files (bibtex equivalent in parentheses):
* journaltitle (journal)
* location (address)
* url (NA)

Example of expected behaviour for 'online' type entry:
Nameth, Namius (2020) 'Webpage title', https://www.supercoolwebsite.xyz

### Other comments

Thanks for the great program!