### PR TITLE
Enable multi-selection with fzf-lua

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -319,7 +319,7 @@ local fzf_bibtex_menu = function(mode)
                         ['alt-m'] = markdown_print,
                 },
                 fzf_bibtex = { ['mode'] = mode },
-                fzf_opts = { ['--prompt'] = 'BibTeX> ',['--header'] = header }
+                fzf_opts = { ["--multi"] = true, ['--prompt'] = 'BibTeX> ', ['--header'] = header }
             })
     end
 end


### PR DESCRIPTION
When using fzf-bibtex with fzf-lua I had to add `['--multi'] = true` to be able to select multiple entries with `tab`.